### PR TITLE
improve fastlane full description

### DIFF
--- a/fastlane/metadata/android/en-CA/full_description.txt
+++ b/fastlane/metadata/android/en-CA/full_description.txt
@@ -1,7 +1,15 @@
-No ads or trackers of any kind.
-Free and open source.
-Enter your custom meds and their dosage limitations.
-Receive a notification when a dose expires.
-Light and dark themes.
+<i>Pill Time</i> is a simple Android app to help you keep track of meds that can be taken as needed (not at a specific time).
 
-The full source code is available at https://github.com/cliambrown/PillTime
+* <b>Enter your meds:</b> choose a name, a colour, and a maximum dosage (e.g. max 2 every 6 hours).
+* <b>Enter your doses</b> (time, date, and amount).
+* Receive a notification when a dose expires.
+
+From the main app screen, see the current status of each med, including total current dose, last time taken, and time until the next dose expires.
+
+<br><b>DISCLAIMER:</b>
+
+This app does not provide any medical advice, implied or otherwise. All information provided by the app is based only on user input and does not constitute a recommendation of any kind. All medical decisions should always be taken in consultation with medical professionals.
+
+This is a simple app made by one person for personal use. It cannot be relied upon for any health-related purposes. Because of technical limitations and known issues, it cannot be guaranteed to provide notifications at specific times. (For example, restarting the phone will unfortunately disable all future notifications from this app.)
+
+This app is not appropriate for meds that need to be taken regularly on a set schedule. It was built to track meds that may be taken when needed, but in limited amounts.

--- a/fastlane/metadata/android/en-GB/full_description.txt
+++ b/fastlane/metadata/android/en-GB/full_description.txt
@@ -1,7 +1,15 @@
-No ads or trackers of any kind.
-Free and open source.
-Enter your custom meds and their dosage limitations.
-Receive a notification when a dose expires.
-Light and dark themes.
+<i>Pill Time</i> is a simple Android app to help you keep track of meds that can be taken as needed (not at a specific time).
 
-The full source code is available at https://github.com/cliambrown/PillTime
+* <b>Enter your meds:</b> choose a name, a colour, and a maximum dosage (e.g. max 2 every 6 hours).
+* <b>Enter your doses</b> (time, date, and amount).
+* Receive a notification when a dose expires.
+
+From the main app screen, see the current status of each med, including total current dose, last time taken, and time until the next dose expires.
+
+<br><b>DISCLAIMER:</b>
+
+This app does not provide any medical advice, implied or otherwise. All information provided by the app is based only on user input and does not constitute a recommendation of any kind. All medical decisions should always be taken in consultation with medical professionals.
+
+This is a simple app made by one person for personal use. It cannot be relied upon for any health-related purposes. Because of technical limitations and known issues, it cannot be guaranteed to provide notifications at specific times. (For example, restarting the phone will unfortunately disable all future notifications from this app.)
+
+This app is not appropriate for meds that need to be taken regularly on a set schedule. It was built to track meds that may be taken when needed, but in limited amounts.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,7 +1,15 @@
-No ads or trackers of any kind.
-Free and open source.
-Enter your custom meds and their dosage limitations.
-Receive a notification when a dose expires.
-Light and dark themes.
+<i>Pill Time</i> is a simple Android app to help you keep track of meds that can be taken as needed (not at a specific time).
 
-The full source code is available at https://github.com/cliambrown/PillTime
+* <b>Enter your meds:</b> choose a name, a colour, and a maximum dosage (e.g. max 2 every 6 hours).
+* <b>Enter your doses</b> (time, date, and amount).
+* Receive a notification when a dose expires.
+
+From the main app screen, see the current status of each med, including total current dose, last time taken, and time until the next dose expires.
+
+<br><b>DISCLAIMER:</b>
+
+This app does not provide any medical advice, implied or otherwise. All information provided by the app is based only on user input and does not constitute a recommendation of any kind. All medical decisions should always be taken in consultation with medical professionals.
+
+This is a simple app made by one person for personal use. It cannot be relied upon for any health-related purposes. Because of technical limitations and known issues, it cannot be guaranteed to provide notifications at specific times. (For example, restarting the phone will unfortunately disable all future notifications from this app.)
+
+This app is not appropriate for meds that need to be taken regularly on a set schedule. It was built to track meds that may be taken when needed, but in limited amounts.


### PR DESCRIPTION
This PR improves on the fastlane full description, adding more details and using a format that renders well as Markdown (supported e.g. at IzzyOnDroid) while staying fully compatible with places not having Markdown support (e.g. F-Droid, PlayStore).

On a side note: descriptions have been identical in all locales here. You don't need to ship them duplicated: elements missing in one locale (e.g. `en-GB`) will be automatically taken from `en-US`, which is the mandatory default locale and fallback for all others. So you might wish to clean up `en-GB` and `en-CA`.