### PR TITLE
Minor fixes in German translation.

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -14,7 +14,7 @@
     </plurals>
     <string name="every">alle</string>
     <string name="hour_or_day">Stunde oder Tag</string>
-    <string name="default_doses">Die üblicherweise eingenommene Menge:</string>
+    <string name="default_doses">Üblicherweise eingenommene Menge:</string>
     <string name="new_med">Neue Medikation</string>
     <string name="history">Verlauf</string>
     <!-- Example: "[X] meds taken in [the] past [Y] hours" -->
@@ -117,7 +117,7 @@
     <string name="theme_entry_auto_battery">Automatisch (Akku)</string>
 
     <string name="color">Farbe</string>
-    <string name="set_med_color">Setz die Farbe der Medikamente auf</string>
+    <string name="set_med_color">Lege die Farbe des Medikaments fest</string>
     <string name="red">Rot</string>
     <string name="orange">Orange</string>
     <string name="amber">Bernstein</string>


### PR DESCRIPTION
With regards to the welcome dialog text: It was quite confusing for me at first, because I thought you were talking about the "Add dose"-FAB, which didn't make sense obviously. In the German translation it is even more explicit, because it says "Dosis hinzufügen" which is exactly the text on the FAB.
I'd suggest you change the English text so that it refers to the plus-button next to the meds item. Or something of the sort. 

And another note wrt the new keepandroidopen.org "dev_decree_notice"-string. I think its now worded in a way that makes it sound like it won't even be an inconvenience for the user. Way too diplomatic imo. Should say that Google is doing evil greedy shit and is trying to make it almost impossible to install free apps.